### PR TITLE
turbolinks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,27 @@ gem 'dfm_web'
 bundle install
 ```
 
-applicaiton.css
+application.css
 ```
  *= require dfm_web/dfm_web
 ```
+
+application.coffee (Turbolinks)
+```
+#= require dfm_web/dfm_web
+
+$(document).on 'turbolinks:load', ->
+  DfmWeb.activate_dfm_web();
+```
+
+application.coffee (Vanilla)
+```
+#= require dfm_web/dfm_web
+
+$(document).on 'ready page:load', ->
+  DfmWeb.activate_dfm_web();
+```
+
 
 application.html.erb
 ```

--- a/app/assets/javascripts/dfm_web/dfm_web.js.coffee
+++ b/app/assets/javascripts/dfm_web/dfm_web.js.coffee
@@ -20,7 +20,8 @@ filter_table_rows = (searched) ->
 # $(document).on 'ready page:load', ->
 #   DfmWeb.activate_dfm_web();
 #
-# Turbolinks: $(document).on 'turbolinks:load', ->
+# Turbolinks:
+# $(document).on 'turbolinks:load', ->
 #   DfmWeb.activate_dfm_web();
 #
 DfmWeb.activate_dfm_web = ->

--- a/app/assets/javascripts/dfm_web/dfm_web.js.coffee
+++ b/app/assets/javascripts/dfm_web/dfm_web.js.coffee
@@ -1,5 +1,9 @@
 # DFM Web Common Javascript
 
+# DfmWeb Namespace
+# https://robots.thoughtbot.com/module-pattern-in-javascript-and-coffeescript
+window.DfmWeb = {};
+
 # Method to filter Table rows by a search query
 # Your table must have the class live_table
 # Your search field must have the class live_search
@@ -11,7 +15,15 @@ filter_table_rows = (searched) ->
   ).hide()
 
 
-$(document).on 'ready page:load', ->
+# Add this method within your initialization block:
+# Vanilla:
+# $(document).on 'ready page:load', ->
+#   DfmWeb.activate_dfm_web();
+#
+# Turbolinks: $(document).on 'turbolinks:load', ->
+#   DfmWeb.activate_dfm_web();
+#
+DfmWeb.activate_dfm_web = ->
 
   # Activate Tablesorter (add to table)
   $('.tablesorter').tablesorter({widgets: ['zebra']}) unless typeof(tablesorter) == "undefined"

--- a/app/assets/stylesheets/dfm_web/nav.css
+++ b/app/assets/stylesheets/dfm_web/nav.css
@@ -2,10 +2,10 @@ nav {
   position:fixed;
   width: 100%;
   top: 0;
-  padding: 20px 25px;
   height: 75px;
   z-index: 999;
   float: left;
+  line-height: 75px;
 }
 
 #nav{
@@ -16,37 +16,43 @@ nav {
 }
 
 #nav * {
-  vertical-align: top;
+  vertical-align: middle;
   position: relative;
   display: inline-block;
   margin: 0;
 }
 
 /* Prevent Menu items from popping out of place on slightly too small windows */
-#nav .right {
+#nav .right, #nav .left {
   position: absolute;
   top: 0;
   height: 75px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+#nav .right {
   right: 25px;
 }
 
 #nav .left {
-  position: absolute;
   left: 25px;
-  overflow: hidden;
-  white-space: nowrap;
 }
 
 
 #nav li {
   top: 0;
   padding: 0 1em;
-  line-height: 75px;
   height: 75px;
   font-size: 1.1em;
 }
 #nav li:hover {
   background-color: #00426e;
+}
+
+/* If you don't want your item's background to change on hover use the "no_hover" class */
+#nav li.no_hover:hover {
+  background-color: inherit;
 }
 
 #nav .left > * { margin: 0 1em; }

--- a/app/assets/stylesheets/dfm_web/style.css.erb
+++ b/app/assets/stylesheets/dfm_web/style.css.erb
@@ -38,7 +38,7 @@ nav, #notice, #alert {
 }
 
 #nav li > div {
-  background-color: rgba(0, 82, 136, 0.78);
+  background-color: rgba(0, 82, 136, 0.98);
 }
 #nav li > div > a:hover {
   background-color: rgba(0, 82, 136, 1);

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "1.0.7"
+  VERSION = "1.1.0"
 end
 
 
 # Version History
 
+# 1.1.0   In order to support both Turbolinks and non-Turbolinks sites, DfmWeb must be manually activated now.
 # 1.0.7   Copied simple versions of _nav and _footer from the dummy app so they won't be missing assets on new apps.
 # 1.0.6   Added "paper" class to simulate printed content.
 # 1.0.5   Form element style improvements.  Added optional Mailer Template.

--- a/spec/dummy/app/views/layouts/_nav.html.erb
+++ b/spec/dummy/app/views/layouts/_nav.html.erb
@@ -1,9 +1,11 @@
 <nav>
   <div id="nav">
+
+    <!-- Use ul+li for menus, or plain div for logos etc.  div tags won't have any hover effects -->
     <div class="left">
       <%= link_to main_app.root_url do %>
         <%= image_tag "dfm_web/uwcrest.png", size: '25x40' %>
-        <h1 class='hover_span'>DFM<span>CH</span> Web</h1>
+        <h1>DFM Web</h1>
       <% end %>
     </div>
 


### PR DESCRIPTION
Fixes #44 

Creates a DfmWeb namespaced function to run the startup code instead of just going for it.  It's one more step, but this way we don't make assumptions on Turbolinks being on the host app.

Just add this: `DfmWeb.activate_dfm_web();` within your `turbolinks:load` or `ready page:load` startup.