### PR TITLE
New nav css

### DIFF
--- a/app/assets/javascripts/dfm_web/dfm_web.js.coffee
+++ b/app/assets/javascripts/dfm_web/dfm_web.js.coffee
@@ -73,12 +73,17 @@ DfmWeb.activate_dfm_web = ->
 
   # If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
   window.onresize = ->
-    if ($(window).width() / parseFloat($("body").css("font-size"))) > 47.938
+
+
+    console.log($(window).width() / parseFloat($("html").css("font-size")));
+
+    if ($(window).width() / parseFloat($("body").css("font-size"))) > 48.0
       $("nav #nav .right").css('display', 'inline-block')
     else
       $("nav #nav .right").css('display', 'none')
 
   # iPads don't have :hover really, so hide the menu if the user clicks anything in <main>
   $('main').click ->
-    $("nav #nav .right").css('display', 'none')
+    if ($(window).width() / parseFloat($("body").css("font-size"))) < 48.0
+      $("nav #nav .right").css('display', 'none')
 

--- a/app/assets/javascripts/dfm_web/dfm_web.js.coffee
+++ b/app/assets/javascripts/dfm_web/dfm_web.js.coffee
@@ -61,8 +61,10 @@ DfmWeb.activate_dfm_web = ->
 
   ### NAV BAR ###
 
-  # Show the Hamburger if there are menu items
+  # Insert the Hamburger if there are menu items
+
   if $('#nav ul.right li').length
+    console.log($('#nav ul.right li').length);
     $('ul.right').after('<div id="hamburger"></div>')
 
   # Show the Mobile Menu on Hamburger Click
@@ -78,5 +80,5 @@ DfmWeb.activate_dfm_web = ->
 
   # iPads don't have :hover really, so hide the menu if the user clicks anything in <main>
   $('main').click ->
-    $("#nav li div:hover").css('display', 'none')
+    $("nav #nav .right").css('display', 'none')
 

--- a/app/assets/javascripts/dfm_web/dfm_web.js.coffee
+++ b/app/assets/javascripts/dfm_web/dfm_web.js.coffee
@@ -61,29 +61,26 @@ DfmWeb.activate_dfm_web = ->
 
   ### NAV BAR ###
 
-  # Insert the Hamburger if there are menu items
-
-  if $('#nav ul.right li').length
-    console.log($('#nav ul.right li').length);
+  # Insert the Hamburger if there are menu 2+ items
+  # Add "has_hamburger" class to the ul so CSS can know which way to show it.
+  if $('#nav ul.right li').length > 1
+    console.log("Hamburger! " + $('#nav ul.right li').length );
     $('ul.right').after('<div id="hamburger"></div>')
+    $('ul.right').addClass('has_hamburger')
 
   # Show the Mobile Menu on Hamburger Click
   $('nav #hamburger').click ->
-    $("nav #nav .right").toggle()
+    $("nav #nav ul.has_hamburger").toggle()
 
   # If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
   window.onresize = ->
-
-
-    console.log($(window).width() / parseFloat($("html").css("font-size")));
-
     if ($(window).width() / parseFloat($("body").css("font-size"))) > 48.0
-      $("nav #nav .right").css('display', 'inline-block')
+      $("nav #nav ul.has_hamburger").css('display', 'inline-block')
     else
-      $("nav #nav .right").css('display', 'none')
+      $("nav #nav ul.has_hamburger").css('display', 'none')
 
   # iPads don't have :hover really, so hide the menu if the user clicks anything in <main>
   $('main').click ->
     if ($(window).width() / parseFloat($("body").css("font-size"))) < 48.0
-      $("nav #nav .right").css('display', 'none')
+      $("nav #nav ul.has_hamburger").css('display', 'none')
 

--- a/app/assets/stylesheets/dfm_web/dfm_web.css
+++ b/app/assets/stylesheets/dfm_web/dfm_web.css
@@ -5,6 +5,7 @@
  *= require ./pure/gutter
  *= require ./layout.css
  *= require ./nav.css
+ *= require ./nav_colors.css
  *= require ./style.css
  *= require ./forms.css
  *= require ./tables.css

--- a/app/assets/stylesheets/dfm_web/layout_media.css
+++ b/app/assets/stylesheets/dfm_web/layout_media.css
@@ -41,8 +41,16 @@
 /* Pure Small */
 @media screen and (max-width:48em) {
 
-  /* Menu Items */
-  nav #nav .right {
+  /* Nav with 1 or 0 items in ul.right */
+  nav #nav ul.right {
+    position: relative;
+    top: 0;
+    right: 0;
+    display: inline-block;
+  }
+
+  /* Nav with 2 or more menu items has_hamburger added via javascript */
+  nav #nav ul.has_hamburger {
     position: relative;
     background-color: rgba(0, 82, 136, .98);
     top: 0;

--- a/app/assets/stylesheets/dfm_web/layout_media.css
+++ b/app/assets/stylesheets/dfm_web/layout_media.css
@@ -5,7 +5,7 @@
 
 /* Large (iPad) and below,  * remove the extra space around <main> */
 /*                          * disabled the fixed nav */
-@media screen and (max-width:79.938em) {
+@media screen and (max-width:80em) {
   body {
     margin-bottom: 2em;      /* space for footer only */
   }
@@ -39,7 +39,7 @@
 
 
 /* Pure Small */
-@media screen and (max-width:47.938em) {
+@media screen and (max-width:48em) {
 
   /* Menu Items */
   nav #nav .right {

--- a/app/assets/stylesheets/dfm_web/layout_media.css
+++ b/app/assets/stylesheets/dfm_web/layout_media.css
@@ -43,23 +43,19 @@
 
   /* Menu Items */
   nav #nav .right {
-    position: absolute;
-    background-color: rgb(0, 82, 136);
-    width: 100%;
-    height: 75px;
+    position: relative;
+    background-color: rgba(0, 82, 136, .98);
     top: 0;
     right: 0;
-    padding: 0;
-    z-index: 99;
     display: none;
   }
+  nav #nav ul.right {
+    float: right;
+  }
+
 
   #nav #hamburger {
     display: block;
-  }
-
-  /* Sub Menus */
-  nav #nav .right li > div {
   }
 
 }

--- a/app/assets/stylesheets/dfm_web/layout_media.css
+++ b/app/assets/stylesheets/dfm_web/layout_media.css
@@ -48,11 +48,11 @@
     top: 0;
     right: 0;
     display: none;
+    clear: both;  /* Make sure to drop the menu down below the nav even if it would otherwise fit. */
   }
   nav #nav ul.right {
     float: right;
   }
-
 
   #nav #hamburger {
     display: block;

--- a/app/assets/stylesheets/dfm_web/nav.css
+++ b/app/assets/stylesheets/dfm_web/nav.css
@@ -3,47 +3,86 @@ nav {
   width: 100%;
   top: 0;
   height: 75px;
-  z-index: 999;
   float: left;
-  line-height: 75px;
 }
 
 #nav{
   width: 100%;
   max-width: 1800px;
   margin: 0 auto;
-  height: 40px;
 }
 
-#nav * {
+#nav img {
   vertical-align: middle;
-  position: relative;
+  margin-right: 1em;
+}
+
+/* We used h1 for the logo in the past, but that's treated as a section heading by screen readers. */
+/*  Please use <span>TITLE<span> */
+
+#nav h1,
+#nav span {
+  padding: 0;
+  margin-right: 20px;
   display: inline-block;
-  margin: 0;
+  vertical-align: middle;
+  line-height: 73px;
+  font-size: 2em;
 }
 
-/* Prevent Menu items from popping out of place on slightly too small windows */
-#nav .right, #nav .left {
-  position: absolute;
-  top: 0;
-  height: 75px;
-  overflow: hidden;
+/* TODO: Input fields don't want to vertically center */
+/* TODO: Had to eyeball it. */
+nav #nav form input[type="text"] {
+  margin-top: 19px;
 }
 
-#nav .right {
-  right: 25px;
-}
-
-#nav .left {
-  left: 25px;
-}
-
-
+#nav ul,
 #nav li {
+  padding: 0;
+  list-style: none;
+  margin: 0;
+    font-size: 20px;
+}
+
+#nav ul {
+  position: relative;
+  z-index: 597;
+}
+
+#nav ul li {
+  float: left;
+  min-height: 1px;
+  vertical-align: middle;
+}
+
+#nav ul li.hover,
+#nav ul li:hover {
+  position: relative;
+  z-index: 599;
+  cursor: default;
+}
+
+#nav ul ul {
+  visibility: hidden;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 598;
+  width: 100%;
+}
+
+#nav ul ul li {
+  float: none;
+}
+
+#nav ul ul ul {
   top: 0;
-  padding: 0 1em;
-  height: 75px;
-  font-size: 1.1em;
+  left: 190px;
+  width: 190px;
+}
+
+#nav ul li:hover > ul {
+  visibility: visible;
 }
 
 /* If you don't want your item's background to change on hover use the "no_hover" class */
@@ -51,44 +90,87 @@ nav {
   background-color: inherit;
 }
 
-#nav .left > * { margin: 0 1em; }
-#nav .left > *:first-child { margin: 0 1em 0 0; }
-#nav .left img { margin-right: 1em; }
 
-
-#nav form {
-  height: 40px;
-  overflow: hidden;
-  margin: 0 20px;
-}
-#nav form input[type=text] {
-  margin-top: 4px;
-  padding-left: 15px;
+#nav ul ul {
+  bottom: 0;
+  left: 0;
 }
 
-/* Ignore styles for links within the nav */
-nav a, nav a:visited {
-  color: white;
+#nav ul ul {
+  margin-top: 0;
 }
 
-#nav li > div {
-  position: fixed; /* This is the only way to break out of the overflow: hidden nav */
-  top: 75px;
-  margin-left: -1em;
-  display: none;
-  min-width: 150px;
-  max-width: 200px;
+#nav ul ul li {
+  font-weight: normal;
 }
 
-#nav li > div a {
+#nav a {
   padding: 0 20px;
-  width: 100%;
-  white-space: nowrap;
+  display: block;
+  line-height: 1em;
+  text-decoration: none;
 }
 
-#nav li:hover > div {
-  display: block;
+
+#nav > ul {
+  *display: inline-block;
 }
+
+#nav:after,
+#nav ul:after {
+  content: '';
+  display: block;
+  clear: both;
+}
+
+#nav ul ul {
+  min-width: 190px;
+}
+
+#nav ul ul a {
+
+  border-top: 0 none;
+  line-height: 150%;
+  padding: 16px 20px;
+}
+#nav ul ul ul {
+  border-top: 0 none;
+}
+#nav ul ul li {
+  position: relative;
+}
+
+
+#nav ul ul li:last-child > a {
+  -moz-border-radius: 0 0 3px 3px;
+  -webkit-border-radius: 0 0 3px 3px;
+  border-radius: 0 0 3px 3px;
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+}
+#nav ul ul li:last-child:hover > a {
+  -moz-border-radius: 0 0 0 3px;
+  -webkit-border-radius: 0 0 0 3px;
+  border-radius: 0 0 0 3px;
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+}
+
+#nav ul li.last ul {
+  left: auto;
+  right: 0;
+}
+#nav ul li.last ul ul {
+  left: auto;
+  right: 99.5%;
+}
+
+#nav > ul > li > a {
+  line-height: 75px;
+}
+
 
 #nav #hamburger {
   display: none;

--- a/app/assets/stylesheets/dfm_web/nav_colors.css
+++ b/app/assets/stylesheets/dfm_web/nav_colors.css
@@ -1,0 +1,14 @@
+/* Top Menus */
+#nav a {
+  color: white;
+}
+
+/* Drop down menus */
+#nav ul ul li {
+  background: rgba(0, 82, 136, 0.98);
+}
+
+/* Hover Color */
+#nav li:hover  {
+  background-color: #00426e;
+}

--- a/app/assets/stylesheets/dfm_web/pure/visibility.css
+++ b/app/assets/stylesheets/dfm_web/pure/visibility.css
@@ -25,7 +25,7 @@ show-for-xlarge-only
 
 
 /* Pure Extra Small */
-@media screen and (max-width:35.438em) {
+@media screen and (max-width:35.5em) {
   .show-for-small-up{display:none !important;}
   .show-for-medium-up{display:none !important;}
   .show-for-large-up{display:none !important;}
@@ -38,7 +38,7 @@ show-for-xlarge-only
 }
 
 /* Pure Small */
-@media screen and (min-width:35.5em) and (max-width:47.938em) {
+@media screen and (min-width:35.5em) and (max-width:48em) {
   .show-for-medium-up{display:none !important;}
   .show-for-large-up{display:none !important;}
   .show-for-xlarge-up{display:none !important;}
@@ -50,7 +50,7 @@ show-for-xlarge-only
 }
 
 /* Pure Medium (iPad Portrait) */
-@media screen and (min-width:48em) and (max-width:63.938em) {
+@media screen and (min-width:48em) and (max-width:64em) {
   .show-for-large-up{display:none !important;}
   .show-for-xlarge-up{display:none !important;}
 
@@ -61,7 +61,7 @@ show-for-xlarge-only
 }
 
 /* Pure Large (iPad Landscape) */
-@media screen and (min-width:64em) and (max-width:79.938em) {
+@media screen and (min-width:64em) and (max-width:80em) {
   .show-for-xlarge-up{display:none !important;}
 
   .show-for-xsmall-only{display:none !important;}

--- a/app/assets/stylesheets/dfm_web/style.css.erb
+++ b/app/assets/stylesheets/dfm_web/style.css.erb
@@ -37,12 +37,6 @@ nav, #notice, #alert {
   margin: 0 auto;
 }
 
-#nav li > div {
-  background-color: rgba(0, 82, 136, 0.98);
-}
-#nav li:hover, #nav li > div > a:hover {
-  background-color: #00426e;
-}
 
 
 

--- a/lib/dfm_web/engine.rb
+++ b/lib/dfm_web/engine.rb
@@ -1,5 +1,5 @@
 module DfmWeb
   class Engine < ::Rails::Engine
-    Engine.config.assets.precompile += %w( dfm_web/* )
+    Engine.config.assets.precompile += %w( dfm_web/* ) rescue nil
   end
 end

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "1.1.1"
+  VERSION = "2.0.0"
 end
 
 
 # Version History
 
+# 2.0.0   Near total rewrite of Nav.  Smarter and more foolproof.  NOTE: Removes optional div/a menus and leaves only the ul/li style.
 # 1.1.1   Added dfm_web assets to the pipeline so you don't have to.
 # 1.1.0   In order to support both Turbolinks and non-Turbolinks sites, DfmWeb must be manually activated now.
 # 1.0.7   Copied simple versions of _nav and _footer from the dummy app so they won't be missing assets on new apps.

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -14,3 +14,7 @@
 //= require     dfm_web/dfm_web
 //= require_tree .
 
+// See dfm_web/dfm_web.js.coffee for information
+$(document).on('ready page:load', function() {
+    return DfmWeb.activate_dfm_web();
+});

--- a/spec/dummy/app/views/layouts/_nav.html.erb
+++ b/spec/dummy/app/views/layouts/_nav.html.erb
@@ -1,32 +1,34 @@
 <nav>
   <div id="nav">
 
-    <!-- Use ul+li for menus, or plain div for logos etc.  div tags won't have any hover effects -->
-    <div class="left">
-      <%= link_to main_app.root_url do %>
-        <%= image_tag "dfm_web/uwcrest.png", size: '25x40' %>
-        <h1>DFM Web</h1>
-      <% end %>
-    </div>
+    <!-- Use ul+li for menus. span around your logo -->
+    <ul class="left">
+      <li class="no_hover">
+        <%= link_to main_app.root_url do %>
+          <%= image_tag "dfm_web/uwcrest.png", size: '25x40' %>
+          <span>DFM Web</span>
+        <% end %>
+      </li>
+    </ul>
 
     <ul class="right">
       <li><%= link_to "Pure", pure_path %></li>
 
       <li>
         <%= link_to("Flash", '#') %>
-        <div>
-          <%= link_to('Notices', notice_path) %>
-          <%= link_to('Alerts', alert_path) %>
-        </div>
+        <ul>
+          <li><%= link_to('Notices', notice_path) %></li>
+          <li><%= link_to('Alerts', alert_path) %></li>
+        </ul>
       </li>
 
       <li>
         <%= link_to "News", news_path %>
-        <div>
-          <%= link_to("#{Date.today.strftime("%A")}'s Weather", news_path + "#weather") %>
-          <%= link_to('Sasuke Flips Car', news_path + "#sasuke") %>
-          <%= link_to('Ricky Faces Jail Time', news_path + "#ricky") %>
-        </div>
+        <ul>
+          <li><%= link_to("#{Date.today.strftime("%A")}'s Weather", news_path + "#weather") %></li>
+          <li><%= link_to('Sasuke Flips Car', news_path + "#sasuke") %></li>
+          <li><%= link_to('Ricky Faces Jail Time', news_path + "#ricky") %></li>
+        </ul>
       </li>
 
       <!-- The last item can't really be a menu because there isn't space. -->

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@
 # The `.rspec` file also contains a few flags that are not defaults but that
 # users commonly want.
 #
+ENV["RAILS_ENV"] ||= 'test'
+
 require 'action_controller/railtie'     # So we can test the Helper.
 require 'rspec/rails'                   # So we can test the Helper.
 require 'dfm_web'


### PR DESCRIPTION
Largely based on http://cssmenumaker.com/menu/flat-accented-dropdown-menu

Removed all the fancy styles and kept just the mechanics.  Added in new Hamburger javascript that's smarter and only kicks in if you have 2 or more items. 

## NOTE! 
Previously nav menus in dfm_web supported foundation style and everybody-else style nesting.  We now support only the everybody-else style.  That is ul / li menus + sub menus.  

If your menu uses 
```html
<div class='right'>
 <a>aaa</a>
 <a>bbb</a>
 <a>bbb</a>
</div>
```

Change the `div` to `ul` and wrap those links in `li` tags.

```html
<ul class='right'>
 <li><a>aaa</a></li>
 <li><a>bbb</a></li>
 <li><a>bbb</a></li>
</ul>
```


![dfm_web](https://user-images.githubusercontent.com/382216/36605018-12b60a00-1885-11e8-8c78-6f97b9f5e5e7.gif)

