### PR TITLE
update position & display

### DIFF
--- a/app/assets/stylesheets/dfm_web/nav.css
+++ b/app/assets/stylesheets/dfm_web/nav.css
@@ -198,6 +198,7 @@ nav > #nav > ul.right {
 #nav ul.crowded{
   max-height: 80vh !important;
   overflow-y: scroll;
-  position: relative;
-  border: 1px solid rgba(255,255,255,.2);
+  position: absolute;
+  display: inline-block;
+  bottom: auto;
 }

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "2.0.4"
+  VERSION = "2.0.5"
 end
 
 
 # Version History
 
+# 2.0.5   Improved the long menu CSS.  No more side-effects!
 # 2.0.4   Really long menus will now show with a compact scrollable menu instead of the default.
 # 2.0.3   No ugly layout flow in the event your right nav ul overlaps with the left.  They just kinda clobber now.  You have too many menus.
 # 2.0.2   Made small and extra small a little smaller.


### PR DESCRIPTION
Fixes #48 

- Making a absolute inline block allows the menu title box to adjust to its text.
- This also eliminates the magic hover issue.

Before:
<img width="599" alt="48_overly_long_menu_need_strategy_yeng_before" src="https://user-images.githubusercontent.com/4133434/37164991-2722ea6c-22c1-11e8-9713-aded3bb633ff.png">

After:
<img width="751" alt="48_overly_long_menu_need_strategy_yeng_after" src="https://user-images.githubusercontent.com/4133434/37165005-2c5e8cc0-22c1-11e8-86f2-aa409583628d.png">
