### PR TITLE
Removed any pending animations before closing #notice/#alert boxes

### DIFF
--- a/app/assets/javascripts/dfm_web/dfm_web.js.coffee
+++ b/app/assets/javascripts/dfm_web/dfm_web.js.coffee
@@ -30,10 +30,15 @@ DfmWeb.activate_dfm_web = ->
   $('.tablesorter').tablesorter({widgets: ['zebra']})
 
   # Hide the #notice and #alert messages by clicking the [X] or pressing escape key
+  # stop(true) removes any pending animations.
+  # This allows you to have an autohide in your app without breaking the click / ESC action.
+  # Example: $('#notice').delay(5000).slideUp('slow')
   $('#notice, #alert').click ->
+    $(this).stop(true)
     $(this).slideUp('slow')
   $(document).keyup (e) ->
     if e.keyCode == 27
+      $('#notice, #alert').stop(true)
       $('#notice, #alert').slideUp('slow')
 
   # Load anything you want with ajax easily.

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "2.0.8"
+  VERSION = "2.0.9"
 end
 
 
 # Version History
 
+# 2.0.9   Added a animation clear on the notice/alert close javascript. This allows you to add new actions in your app.
 # 2.0.8   Refreshed Print styles.  Hides Nav, Footer and removes empty space around major elements.
 # 2.0.7   Added table to kitchen sink.  Tablesorter is now a added to the dummy app.
 # 2.0.6   Robust ajax_load method imported.  Will not render errors / huge responses.


### PR DESCRIPTION
Fixes #54 

Just adds `.stop(true)` before adding the hide animation when you click the close button or ESC key.

Lets you then add stuff like this to your host app without breaking DfmWeb's behavior.
```coffeescript
$('#notice').delay(5000).slideUp('slow')
```