### PR TITLE
Fix disappearing menu with 1037px wide Chrome window.

### DIFF
--- a/app/assets/javascripts/dfm_web/dfm_web.js.coffee
+++ b/app/assets/javascripts/dfm_web/dfm_web.js.coffee
@@ -91,14 +91,14 @@ DfmWeb.activate_dfm_web = ->
 
   # If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
   window.onresize = ->
-    if $(window).width() > 1023
+    if window.innerWidth > 1023
       $("nav #nav ul.has_hamburger").css('display', 'inline-block')
     else
       $("nav #nav ul.has_hamburger").css('display', 'none')
 
   # iPads don't have :hover really, so hide the menu if the user clicks anything in <main>
   $('main').click ->
-    if $(window).width() <= 1023
+    if window.innerWidth <= 1023
       $("nav #nav ul.has_hamburger").css('display', 'none')
 
   # Deal with Really long menus

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "2.1.3"
+  VERSION = "2.1.4"
 end
 
 
 # Version History
 
+# 2.1.4   Fixed menu bug when browser was exactly 1037px wide with a scrollbar.
 # 2.1.3   New Table TR modifier classes: okay, highlight, warn, alert, gray.
 # 2.1.2   Add submit buttons w/ modifier classes below "button" links with the same classes to the kitchen sink.
 # 2.1.1   Eliminate a visual jump when resizing from L to XL.


### PR DESCRIPTION
Switched the technique of determining window width in Javascript to one that ignores scrollbars.