### PR TITLE
Trying a non-hacky way to remove pixel

### DIFF
--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title>DFM Web Kitchen Sink</title>
     <%= csrf_meta_tags %>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => 'reload' %>
 


### PR DESCRIPTION
FIxes #62 
I can't really test it on my browser, so trying this out according an old post on [Stack Overflow](https://stackoverflow.com/questions/6098256/a-1-pixel-gap-only-coming-on-ipad-but-fine-on-safari-and-chrome)
- Instead of pulling the whole menu 1 pixel up on ipad size, I want to see if this will solve the 1 pixel issue on ipad since all margins and top are set to 0 already.  
- This only sets the minimum to 1.0 scale, therefore not effecting zooming on ipad/mobile