### PR TITLE
added transparent background color to body css

### DIFF
--- a/app/assets/stylesheets/dfm_web/layout.css
+++ b/app/assets/stylesheets/dfm_web/layout.css
@@ -17,6 +17,7 @@ html {
 
 body {
   margin: 0 0 100px 0;      /* space for footer & some slack */
+  background-color: transparent;
 }
 
 #notice, #alert {


### PR DESCRIPTION
~~~bash
#
# adding bootstrap css to dfm_web based project
# causes the <main> margins to render
# as solid color (see attached images)
#

#
# steps to reproduce in demo app
#

# create a new dfm_web based project
git clone https://github.com/josheliason/dfm_web_demo.git

cd dfm_web_demo

# append bootstrap gem to Gemfile
vi Gemfile
  gem 'bootstrap', '~> 4.1.0'

bundle install

# per bootstrap docs, use application.css.scss
# https://github.com/twbs/bootstrap-rubygem
cd app/assets/stylesheets
mv application.css application.css.scss

# per bootstrap docs, use @import for bootstrap
vi application.css.scss

/*
 *= require dfm_web/dfm_web
 */
@import "bootstrap";
@import "welcome";
@import "people";

# run rails server
# the <main> area has solid color margin left and right
rails s

#
# fix
#

cd app/assets/stylesheets

# append application.css.scss
@import "layout";

# fix - add 'background-color: transparent;' to body {}
# body {} is from dfm_web/app/assets/stylesheets/dfm_web/layout.css
vi layout.css

body {
  margin: 0 0 100px 0;      /* space for footer & some slack */
  background-color: transparent;
}

# run rails server again
# the <main> margins render as normal showing the background image
rails s
~~~
With bootstrap CSS gem installed and no fix:
<img width="1278" alt="main_margin_before" src="https://user-images.githubusercontent.com/15785483/39209556-b37894d8-47cb-11e8-9e08-beb32eebdc5c.png">

With bootstrap CSS and fix applied:
<img width="1279" alt="main_margin_after" src="https://user-images.githubusercontent.com/15785483/39209564-b9e7313a-47cb-11e8-9f79-c46b07bb87fb.png">

