### PR TITLE
Shifted most media ranges by 1px so 1024px wide iPad is now Large ins…

### DIFF
--- a/app/assets/stylesheets/dfm_web/pure/visibility.css
+++ b/app/assets/stylesheets/dfm_web/pure/visibility.css
@@ -10,6 +10,11 @@ Update:
   The basic visibility classes should never break from user styles.
   !important is a bad practice in general, but this was the only way to ensure expected behavior.
 
+| Extra Small |    Small    |    Medium    |     Large     | Extra Large |
+| <------ 399 | 400 --- 639 | 640 --- 1023 | 1024 --- 1279 | 1280 -----> |
+
+show-for-xsmall-only
+
 show-for-small-up
 show-for-small-only
 
@@ -35,7 +40,7 @@ show-for-xlarge-only
 }
 
 /* Pure Large */
-@media screen and (max-width:1280px) {
+@media screen and (max-width:1279px) {
   .show-for-xlarge-up{display:none !important;}
 
   .show-for-xsmall-only{display:none !important;}
@@ -46,7 +51,7 @@ show-for-xlarge-only
 }
 
 /* Pure Medium (iPad Portrait) */
-@media screen and (max-width:1024px) {
+@media screen and (max-width:1023px) {
   .show-for-large-up{display:none !important;}
   .show-for-xlarge-up{display:none !important;}
 
@@ -58,7 +63,7 @@ show-for-xlarge-only
 }
 
 /* Pure Small */
-@media screen and (max-width:640px) {
+@media screen and (max-width:639px) {
   .show-for-medium-up{display:none !important;}
   .show-for-large-up{display:none !important;}
   .show-for-xlarge-up{display:none !important;}
@@ -71,7 +76,7 @@ show-for-xlarge-only
 }
 
 /* Pure Extra Small */
-@media screen and (max-width:400px) {
+@media screen and (max-width:399px) {
   .show-for-small-up{display:none !important;}
   .show-for-medium-up{display:none !important;}
   .show-for-large-up{display:none !important;}

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "2.1.6"
+  VERSION = "2.1.7"
 end
 
 
 # Version History
 
+# 2.1.7   Shifted the visibility media queries by 1 px (except xlarge). Most important, large starts at 1024px instead of 1025px.
 # 2.1.6   Added okay/highlight/warn/alert/gray class rules to panel, lists, headers, buttons, p where missing.
 # 2.1.5   Added explicit transparent background on body to aid combining DfmWeb with other CSS frameworks.
 # 2.1.4   Fixed menu bug when browser was exactly 1037px wide with a scrollbar.


### PR DESCRIPTION
Fixes #69 

We had an issue with nav items not showing on 1024px wide screens.  The problem was that `medium` was ending at 1024, which means large starts at 1025.

I think that was intentional.  "Large is anything bigger than an iPad."   1024 is a very common landscape width though, and by making portrait mode `medium` and landscape `large` you can more easily customize menus etc for tablets.

