### PR TITLE
Replaced relative lighter/bolder font weights in tables with fixed values

### DIFF
--- a/app/assets/stylesheets/dfm_web/tables.css
+++ b/app/assets/stylesheets/dfm_web/tables.css
@@ -4,7 +4,7 @@ table {
   width: 100%;
   border: 1px solid rgba(0,0,0,.2);
   margin-bottom: 20px;
-  font-weight: lighter;
+  font-weight: 300;
   background-color: white; /* Override this in your app to match your style. */
 }
 table thead  { display: table-header-group; }
@@ -25,15 +25,15 @@ td, th {
 thead th {
   background-color: #dadfe1;
   color:  rgba(0,0,0,.6);
-  font-weight: normal;
+  font-weight: 400;
 }
 
 tbody th {
   background-color: rgba(0, 0, 0, 0.08);
-  font-weight: lighter;
+  font-weight: 300;
 }
 tfoot th {
-  font-weight: bold;
+  font-weight: 500;
 }
 
 

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "4.0.3"
+  VERSION = "4.0.4"
 end
 
 
 # Version History
 
+# 4.0.4   Improved font appearance in tables when verlog.css isn't available.
 # 4.0.3   Removed incorrect html background-color from <= Large sizes.
 # 4.0.2   Optimize png files and add spacing to word/excel.
 # 4.0.1   Minor tweak to manifest.js files


### PR DESCRIPTION
Fixes #76 

* `verlog.css` is only available to licenced parties. When missing, text in tables was too light.
* Changes `font-weight` arguments to static values instead of relative.


### verlog.css present:
<img width="1104" alt="Screen Shot 2019-11-22 at 10 39 44 AM" src="https://user-images.githubusercontent.com/382216/69443838-d3138400-0d14-11ea-8416-342907b4684d.png">

### verlog.css absent:
<img width="1100" alt="Screen Shot 2019-11-22 at 10 39 30 AM" src="https://user-images.githubusercontent.com/382216/69443843-d4dd4780-0d14-11ea-809b-ab63d628c88e.png">

---------------


 Before | After
--------|---------
<img width="1001" alt="Screen Shot 2019-11-15 at 4 00 51 PM" src="https://user-images.githubusercontent.com/382216/68978722-2ccdf880-07c1-11ea-86d5-1330b7794959.png"> | <img width="1100" alt="Screen Shot 2019-11-22 at 10 39 30 AM" src="https://user-images.githubusercontent.com/382216/69443843-d4dd4780-0d14-11ea-809b-ab63d628c88e.png">

