### PR TITLE
Improved Print CSS.

### DIFF
--- a/app/assets/stylesheets/dfm_web/print.css
+++ b/app/assets/stylesheets/dfm_web/print.css
@@ -1,3 +1,9 @@
+/* This fixes the zero print margin issue without adding extra */
+@page {
+  size: auto;
+  margin: 0;
+}
+
 @media print and (color) {
   * {
     /* Prevent browsers from discarding the majority of color info */
@@ -8,6 +14,7 @@
 
 
   body, html, main, #main {
+    background-image: none; /* Safari */
     background-color: white;
     border: none;
     box-shadow: none;
@@ -25,17 +32,21 @@
     font-size: 12pt;
   }
 
-  html        { font-size: 75%; margin: 2px; }
-  a           { text-decoration: none;}
+  /* General tweaks */
+  html        { font-size: 80%; margin: 0.25in; min-height: 0; }
+  a           { text-decoration: none; }
+  .field      { page-break-inside: avoid; }
+  hr          { display: none; }
   table th,
   table td    { padding: 3px; }
 
   /* Stuff to hide */
   /* NOTE: "display: none" breaks unrelated table printing in Chrome */
-  nav, footer, .button, .no_print, input[type=submit] {
+  nav, footer, .button, .no_print, input[type=submit], #notice, #alert {
     position: absolute;
     visibility: hidden;
   }
+
   /* Hide Tablesorter sorting indicators */
   table.tablesorter thead th {
     background-image: none;
@@ -45,5 +56,18 @@
   /* contents of "table_hover" cells should appear in printouts. */
   table tr td.table_hover{
     color: black !important;
+  }
+
+  /* The plain panel divs clutter up the page in print. */
+  /* Remove their style.  Note we add it back to modifier panels below. */
+  .panel {
+    border-width: 0;
+    padding: 0;
+  }
+
+  /* Add back the panel padding when there is a modifier class as well. */
+  .panel.okay, .panel.highlight, .panel.warn, .panel.alert, .panel.gray {
+    border-width: 1px;
+    padding: 20px;
   }
 }

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "4.0.4"
+  VERSION = "4.0.5"
 end
 
 
 # Version History
 
+# 4.0.5   Improved Print CSS.
 # 4.0.4   Improved font appearance in tables when verlog.css isn't available.
 # 4.0.3   Removed incorrect html background-color from <= Large sizes.
 # 4.0.2   Optimize png files and add spacing to word/excel.


### PR DESCRIPTION
Fixes #78 
* Defines `@page` and adjusts borders, margins etc to improve printing.
* Fixes issue with `#notice` `#alert` taking up space even though they don't display.
* Fixes issue with extra height on `html` sometimes causing an extra blank page to print.
* Hide `.panel` styles which just looked cluttered in print.
* Hide `html` background image for Safari users.

### Note:
* Developed in Chrome, verified as _adequate_ in Safari and Firefox.

BEFORE | AFTER
---------|-------
<img width="1564" alt="Screen Shot 2020-01-17 at 1 27 50 PM" src="https://user-images.githubusercontent.com/382216/72640390-663ff300-392d-11ea-876e-38c91f3bb9cc.png"> | <img width="1516" alt="Screen Shot 2020-02-13 at 10 00 41 AM" src="https://user-images.githubusercontent.com/382216/74453252-c13f0a00-4e47-11ea-90e5-36d1cadc676e.png">
