### PR TITLE
Fix deprecation.  Removed excel_icon helper.

### DIFF
--- a/app/helpers/dfm_web_helper.rb
+++ b/app/helpers/dfm_web_helper.rb
@@ -1,10 +1,15 @@
 module DfmWebHelper
 
-
-  def excel_icon(link = params.merge(:format => "xlsx"))
-    # Create Excel icon in consistent location
-    content_for :excel do
-      link_to(image_tag('excel.png', :width => 40, :height => 40), link)
+  # Extract the host application's name and titlecase it.
+  # Should `titlecase` incorrectly capitalize your app, add it
+  # as an acronym in your inflections.rb
+  # > inflect.acronym("HRMed")
+  def host_application_title
+    if Rails::VERSION::MAJOR >= 6
+      Rails.application.class.module_parent_name.to_s.titlecase
+    else
+      Rails.application.class.parent_name.to_s.titlecase
     end
   end
+
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -22,7 +22,7 @@
 </head>
 
 <body>
-  <h6><%= Rails.application.class.parent_name %></h6>
+  <h6><%= host_application_title %></h6>
   <div id="sasuke">
     <div id="yield">
       <%= yield %>

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "4.0.6"
+  VERSION = "4.0.7"
 end
 
 
 # Version History
 
+# 4.0.7   Fix deprecation with Rails 6+. Removed insecure excel_icon helper.
 # 4.0.6   Updated Mailer template.
 # 4.0.5   Improved Print CSS.
 # 4.0.4   Improved font appearance in tables when verlog.css isn't available.

--- a/spec/helpers/dfm_web_helper_spec.rb
+++ b/spec/helpers/dfm_web_helper_spec.rb
@@ -1,5 +1,8 @@
 describe DfmWebHelper, type: :helper do
 
-
+  # Note: We have no host application to extract from here.
+  it "host_application_title extracts the host app title" do
+    expect(host_application_title).to eq ""
+  end
 
 end


### PR DESCRIPTION
Fixes #82 

* Extract host app name with different method depending on rails 5 / 6.
* Remove excel_icon helper which used insecure param merging
  - Couldn't possibly have been used since [around 2016](https://github.com/rails/rails/issues/26289).