### PR TITLE
print CSS updates

### DIFF
--- a/app/assets/stylesheets/dfm_web/dark_mode.css
+++ b/app/assets/stylesheets/dfm_web/dark_mode.css
@@ -1,5 +1,7 @@
 @media (prefers-color-scheme: dark) {
 
+  /* This older declaration is still required for the scrollbar on most browsers in 2021 */
+  :root { color-scheme: dark; }
 
   html, main #main {
     background: none;
@@ -125,4 +127,17 @@
   #nav ul li:hover  {
     background-color: #b40000;
   }
+
+  /* Search Fields */
+  #nav input[type="text"] {
+    opacity: 100%;
+    background-color: #540e0b !important;
+    border-color: #f7f7f7 !important;
+  }
+  #nav input[type="text"]::placeholder {
+    color: #ccc;
+  }
+
+
+
 }

--- a/app/assets/stylesheets/dfm_web/nav.css
+++ b/app/assets/stylesheets/dfm_web/nav.css
@@ -31,7 +31,7 @@ nav {
 /* TODO: Input fields don't want to vertically center */
 /* TODO: Had to eyeball it. */
 nav #nav form input[type="text"] {
-  margin: 5px auto 0 auto;
+  margin: 6px auto 0 auto;
   height: 31px;
 }
 

--- a/app/assets/stylesheets/dfm_web/print.css
+++ b/app/assets/stylesheets/dfm_web/print.css
@@ -39,17 +39,22 @@
   hr          { display: none; }
   table th,
   table td    { padding: 3px; }
+  thead       { display: table-row-group; }
 
   /* Stuff to hide */
-  /* NOTE: "display: none" breaks unrelated table printing in Chrome */
   nav, footer, .button, .no_print, input[type=submit], #notice, #alert {
     position: absolute;
     visibility: hidden;
+    display: none;
+  }
+
+  .print_only {
+    display: inherit !important;
   }
 
   /* Hide Tablesorter sorting indicators */
-  table.tablesorter thead th {
-    background-image: none;
+  table.tablesorter thead tr th {
+    background-image: none !important;
     padding-left: 3px;
   }
 
@@ -70,4 +75,9 @@
     border-width: 1px;
     padding: 20px;
   }
+}
+
+/* Add for content which should only show in print */
+.print_only {
+  display: none;
 }

--- a/app/assets/stylesheets/dfm_web/pure/visibility.css
+++ b/app/assets/stylesheets/dfm_web/pure/visibility.css
@@ -24,55 +24,55 @@ show-for-xlarge-only
 
 /* Pure Extra Large */
 @media screen and (min-width:1280px) {
-  .show-for-xsmall-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-small-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-medium-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-large-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xlarge-only {visibility:visible; position: inherit;}
+  .show-for-xsmall-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-small-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-medium-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-large-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xlarge-only {visibility:visible; position: inherit;  display: inherit;}
 }
 
 /* Pure Large */
 @media screen and (max-width:1279px) {
-  .show-for-xlarge-up   {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xsmall-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-small-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-medium-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-large-only  {visibility:visible; position: inherit;}
-  .show-for-xlarge-only {visibility:hidden;  position: absolute; left: -9999px;}
+  .show-for-xlarge-up   {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xsmall-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-small-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-medium-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-large-only  {visibility:visible; position: inherit;  display: inherit;}
+  .show-for-xlarge-only {visibility:hidden;  position: absolute; display: none;}
 }
 
 /* Pure Medium (iPad Portrait) */
 @media screen and (max-width:1023px) {
-  .show-for-large-up    {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xlarge-up   {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xsmall-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-small-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-medium-only {visibility:visible; position: inherit;}
-  .show-for-large-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xlarge-only {visibility:hidden;  position: absolute; left: -9999px;}
+  .show-for-large-up    {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xlarge-up   {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xsmall-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-small-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-medium-only {visibility:visible; position: inherit;  display: inherit;}
+  .show-for-large-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xlarge-only {visibility:hidden;  position: absolute; display: none;}
 }
 
 /* Pure Small */
 @media screen and (max-width:639px) {
-  .show-for-medium-up   {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-large-up    {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xlarge-up   {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xsmall-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-small-only  {visibility:visible; position: inherit;}
-  .show-for-medium-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-large-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xlarge-only {visibility:hidden;  position: absolute; left: -9999px;}
+  .show-for-medium-up   {visibility:hidden;  position: absolute; display: none;}
+  .show-for-large-up    {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xlarge-up   {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xsmall-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-small-only  {visibility:visible; position: inherit;  display: inherit;}
+  .show-for-medium-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-large-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xlarge-only {visibility:hidden;  position: absolute; display: none;}
 }
 
 /* Pure Extra Small */
 @media screen and (max-width:359px) {
-  .show-for-small-up    {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-medium-up   {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-large-up    {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xlarge-up   {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xsmall-only {visibility:visible; position: inherit;}
-  .show-for-small-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-medium-only {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-large-only  {visibility:hidden;  position: absolute; left: -9999px;}
-  .show-for-xlarge-only {visibility:hidden;  position: absolute; left: -9999px;}
+  .show-for-small-up    {visibility:hidden;  position: absolute; display: none;}
+  .show-for-medium-up   {visibility:hidden;  position: absolute; display: none;}
+  .show-for-large-up    {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xlarge-up   {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xsmall-only {visibility:visible; position: inherit;  display: inherit;}
+  .show-for-small-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-medium-only {visibility:hidden;  position: absolute; display: none;}
+  .show-for-large-only  {visibility:hidden;  position: absolute; display: none;}
+  .show-for-xlarge-only {visibility:hidden;  position: absolute; display: none;}
 }

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "4.1.2"
+  VERSION = "4.1.3"
 end
 
 
 # Version History
 
+# 4.1.3   Accessibility and Print media improvements. Added /print demo to Dummy app.
 # 4.1.2   Add example theme-colors to dummy & Update NAV CSS. Added a nav search box.
 # 4.1.1   Remove alpha channel on option/select background as it's unsupported in Windows.
 # 4.1.0   Add dark-mode (automatic based on system dark/light mode)

--- a/spec/dummy/app/views/application/print.html.erb
+++ b/spec/dummy/app/views/application/print.html.erb
@@ -1,0 +1,46 @@
+<h1>Printing</h1>
+
+<h3>Available Classes:</h3>
+<ul>
+  <li>
+    <code>no_print</code>
+    <ul>
+      <li>Useful for hiding forms, buttons etc.</li>
+    </ul>
+  </li>
+  <li>
+    <code>print_only</code>
+    <ul>
+      <li>Add print friendly content without affecting the screen layout.</li>
+      <li>Print-Preview this page to see an example.</li>
+    </ul>
+  </li>
+</ul>
+
+<hr>
+
+<div class="panel">
+  <h2>Normal Content</h2>
+  <ul>
+    <li>This section will show on screen and in print.</li>
+  </ul>
+</div>
+
+<div class="panel no_print">
+  <h2>No Print</h2>
+  <ul>
+    <li>class: "no_print"</li>
+    <li>This content will show on screen but will not be printed.</li>
+  </ul>
+</div>
+
+<div class="panel print_only">
+  <h2>Print Only</h2>
+  <ul>
+    <li>class: "print_only"</li>
+    <li>This content will only show in print.</li>
+  </ul>
+</div>
+
+
+

--- a/spec/dummy/app/views/layouts/_nav.html.erb
+++ b/spec/dummy/app/views/layouts/_nav.html.erb
@@ -19,6 +19,7 @@
 
       <li><%= link_to "Mailers", "/rails/mailers/mailer/example" %></li>
       <li><%= link_to "Pure", pure_path %></li>
+      <li><%= link_to "Print", print_path %></li>
 
       <li>
         <%= link_to("Flash", '#') %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get 'alert'  => 'application#alert'
   get 'notice' => 'application#notice'
   get 'news'   => 'application#news'
+  get 'print'  => 'application#print'
   get 'pure'   => 'application#pure'
   post 'form_submit' => 'application#form_submit'
   root 'application#index' #You can have the root of your site routed with "root"


### PR DESCRIPTION
Fixes #86 

# Description
* Mostly changes to the `Pure-*` visibility classes.
  - Balanced the use of `visibility` and `display` to prevent excess printed whitespace while maintaining the proper onscreen flow of hidden / shown elements.
* Added a "Print" page demonstrating `no_print` and `print_only` classes
* Added a small dark-mode accessibility tweak to nav search boxes.