### PR TITLE
Remove jQuery requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,51 @@ Gemfile
 gem 'dfm_web'
 ```
 
+Terminal:
 ```bash
 bundle install
 ```
+
+application.html.erb
+```
+  <body>
+    <%= render 'layouts/nav' %>
+    <%= render 'layouts/flash' %>
+    <%= render 'layouts/main' %>
+    <%= render 'layouts/footer' %>
+  </body>
+```
+
+
+# Rails 7
+* Tested using esbuild and sass
+* If not using Turbo, see dfm_web.js for variations on the activation step.
+
+application.html.erb
+```
+<%= stylesheet_link_tag "dfm_web/dfm_web", "data-turbo-track": "reload" %>
+<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+<%= javascript_include_tag "dfm_web/dfm_web", "data-turbo-track": "reload", defer: true %>
+<%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+```
+
+application.js
+```js
+document.addEventListener("turbo:load", function() {
+  DfmWeb.activate_dfm_web();
+})
+```
+
+manifest.js
+```
+//= link dfm_web/manifest.js
+```
+
+-------------------------------------------------------------------------------
+
+# Rails 5/6
+* Webpacker doesn't support assets from gems.
+* We're assuming a traditional sprockets asset-pipeline setup.
 
 application.css
 ```
@@ -36,21 +78,21 @@ $(document).on 'ready page:load', ->
 ```
 
 
-application.html.erb
-```
-  <body>
-    <%= render 'layouts/nav' %>
-    <%= render 'layouts/flash' %>
-    <%= render 'layouts/main' %>
-    <%= render 'layouts/footer' %>
-  </body>
-```
 
 config/initializers/assets.rb
 ```
 Rails.application.config.assets.precompile += %w( dfm_web/* )
 ```
-### Notes on Version 4:
+
+# Changelog:
+
+### Version 5:
+* jQuery is no longer a requirement, though it will work just fine if you use it.
+* All jQuery based code has been rewritten in Javascript (ES6)
+* Updated README and comments on use with Rails 7 (Turbo or plain).
+  - Rails 7 tests were performed on an esbuild + sass setup
+
+### Version 4:
 * Now using the UW look and feel.
 * UW font (verlag) cannot be added to the repo per licensing requirements.
   - To use it in your site add verlag.css to your host app (provided by UW).
@@ -60,7 +102,7 @@ Rails.application.config.assets.precompile += %w( dfm_web/* )
   - Image be scaled to 42px, but PNG should be at least double that.
 
 
-### Notes on Version 3+:
+### Version 3:
 * Javascript to do things other than run the the actual layout has been removed. Specifically:
   - ajax_load
   - auto_submit
@@ -70,19 +112,6 @@ Rails.application.config.assets.precompile += %w( dfm_web/* )
   - live_table
   - tablesorter
 * If you used these features you'll need to pull the javascript from [version 2](https://github.com/DFMCH/dfm_web/blob/518833db5cbbc9aabcfd7ea60dc9960ae67d3406/app/assets/javascripts/dfm_web/dfm_web.js.coffee)
-
-### Things to remove from your app:
-* `scaffold.css`
-* `<p id="notice"><%= notice %></p>` Anywhere in your app.
-
-### Notes on Sprocket 4.0
-* A new [manifest.js](app/assets/config/dfm_web/manifest.js) file has been added for compatibility with Sprockets 4+.
-* Please report any issues or suggestions with this new configuration.
-
-### Notes on Webpack
-* Webpack may be incompatible at the moment.
-  - See https://github.com/DFMCH/dfm_web/issues/74.
-  - Help wanted.
 
 ## Kitchen Sink:
 * To see the Kitchen Sink, go to spec/dummy and run `rails server`

--- a/app/assets/javascripts/dfm_web/dfm_web.js
+++ b/app/assets/javascripts/dfm_web/dfm_web.js
@@ -53,7 +53,7 @@ DfmWeb.activate_dfm_web = function() {
 
     // If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
     window.onresize = function() {
-        if (window.innerWidth > 1023) {
+        if (document.window.innerWidth >= 1024) {
             document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
                 node.style.display = 'inline-block';
             });
@@ -67,7 +67,7 @@ DfmWeb.activate_dfm_web = function() {
     // iPads don't have :hover, so hide the menu if the user clicks anything in <main>
     document.querySelectorAll('main').forEach(node => {
         node.addEventListener('click', () => {
-            if (window.innerWidth <= 1023) {
+            if (document.documentElement.clientWidth < 1024) {
                 document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
                     node.style.display = 'none';
                 });

--- a/app/assets/javascripts/dfm_web/dfm_web.js
+++ b/app/assets/javascripts/dfm_web/dfm_web.js
@@ -4,17 +4,20 @@
 // https://robots.thoughtbot.com/module-pattern-in-javascript-and-coffeescript
 window.DfmWeb = {};
 
-// Add this method within your initialization block:
-// jQuery
-// $(document).on 'ready page:load', ->
-//   DfmWeb.activate_dfm_web();
+// To use the dfm_web.js code, you need to call `DfmWeb.activate_dfm_web();`
+// Here are some examples of how you might do that in your application.js
 
-// jQuery + Turbolinks
-// $(document).on 'turbolinks:load', ->
-//   DfmWeb.activate_dfm_web();
+// Rails 6 Javascript
+// document.addEventListener("DOMContentLoaded", function() { DfmWeb.activate_dfm_web(); });
 
-// Vanilla
-// document.addEventListener("DOMContentLoaded",function() {DfmWeb.activate_dfm_web();});
+// Rails 7 Javascript + Turbo (esbuild in my test)
+// document.addEventListener("turbo:load", function() { DfmWeb.activate_dfm_web(); })
+
+// Rails 6 jQuery
+// $(document).on('ready page:load', function() { DfmWeb.activate_dfm_web(); });
+
+// Rails 6 jQuery + Turbolinks
+// $(document).on('turbolinks:load', function() { DfmWeb.activate_dfm_web(); });
 
 
 DfmWeb.activate_dfm_web = function() {

--- a/app/assets/javascripts/dfm_web/dfm_web.js
+++ b/app/assets/javascripts/dfm_web/dfm_web.js
@@ -54,22 +54,32 @@ DfmWeb.activate_dfm_web = function() {
     // If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
     window.onresize = function() {
         if (window.innerWidth > 1023) {
-            return $("nav #nav ul.has_hamburger").css('display', 'inline-block');
+            document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
+                node.style.display = 'inline-block';
+            });
         } else {
-            return $("nav #nav ul.has_hamburger").css('display', 'none');
+            document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
+                node.style.display = 'none';
+            });
         }
     };
 
     // iPads don't have :hover, so hide the menu if the user clicks anything in <main>
-    $('main').click(function() {
-        if (window.innerWidth <= 1023) {
-            return $("nav #nav ul.has_hamburger").css('display', 'none');
-        }
+    document.querySelectorAll('main').forEach(node => {
+        node.addEventListener('click', () => {
+            if (window.innerWidth <= 1023) {
+                document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
+                    node.style.display = 'none';
+                });
+            }
+        });
     });
+
     // Deal with Really long menus
-    return $("#nav > ul > li > ul").each(function() {
-        if ($(this).children('li').length > 10) {
-            return $(this).addClass('crowded');
+    // Add "crowded" class to make them more compact.
+    document.querySelectorAll("#nav > ul > li > ul").forEach(node => {
+        if (node.children.length > 10) {
+            node.classList.add('crowded');
         }
     });
 };

--- a/app/assets/javascripts/dfm_web/dfm_web.js
+++ b/app/assets/javascripts/dfm_web/dfm_web.js
@@ -16,24 +16,20 @@ window.DfmWeb = {};
 
 DfmWeb.activate_dfm_web = function() {
 
-    // Hide the #notice and #alert messages by clicking the [X] or pressing escape key
-    // stop(true) removes any pending animations.
-    // This allows you to have an autohide in your app without breaking the click / ESC action.
-    // Example: $('#notice').delay(5000).slideUp('slow')
-    $('#notice, #alert').click(function() {
-        $(this).stop(true);
-        return $(this).animate({
-            height: 'toggle'
-        }, 300);
+  // Hide the #notice and #alert messages by clicking the [X] or pressing escape key
+  document.querySelectorAll('#notice, #alert').forEach(node => {
+    node.addEventListener('click', (event) => {
+      console.log(node);
+      node.style.display = 'none';
     });
-    $(document).keyup(function(e) {
-        if (e.keyCode === 27) {
-            $('#notice, #alert').stop(true);
-            return $('#notice, #alert').animate({
-                height: 'toggle'
-            }, 300);
-        }
+
+    // If either ID exists, close by pressing Escape
+    document.addEventListener('keyup', (key) => {
+      if (key.code == 'Escape') {
+        node.style.display = 'none';
+      }
     });
+  });
 
     // NAV BAR
     //

--- a/app/assets/javascripts/dfm_web/dfm_web.js
+++ b/app/assets/javascripts/dfm_web/dfm_web.js
@@ -1,85 +1,87 @@
 // DFM Web Javascript
-// Originally written in coffeescript, converted to JS with http://js2.coffee/
 
 // DfmWeb Namespace
 // https://robots.thoughtbot.com/module-pattern-in-javascript-and-coffeescript
 window.DfmWeb = {};
 
 // Add this method within your initialization block:
-// Vanilla:
+// jQuery
 // $(document).on 'ready page:load', ->
 //   DfmWeb.activate_dfm_web();
 
-// Turbolinks:
+// jQuery + Turbolinks
 // $(document).on 'turbolinks:load', ->
 //   DfmWeb.activate_dfm_web();
 
+// Vanilla
+// document.addEventListener("DOMContentLoaded",function() {DfmWeb.activate_dfm_web();});
+
+
 DfmWeb.activate_dfm_web = function() {
-
-    // Hide the #notice and #alert messages by clicking the [X] or pressing escape key
-    document.querySelectorAll('#notice, #alert').forEach(node => {
-        node.addEventListener('click', () => {
-            node.style.display = 'none';
-        });
-
-        // If either ID exists, close by pressing Escape
-        document.addEventListener('keyup', (key) => {
-            if (key.code == 'Escape') {
-                node.style.display = 'none';
-            }
-        });
+  // Hide the #notice and #alert messages by clicking the [X] or pressing escape key
+  document.querySelectorAll('#notice, #alert').forEach((node) => {
+    node.addEventListener('click', () => {
+      node.style.display = 'none';
     });
 
-    // NAV BAR
-    //
-    // Insert the Hamburger if there are menu 2+ items
-    // Add "has_hamburger" class to the ul so CSS can know which way to show it.
-    if (document.querySelectorAll('#nav ul.right>li').length > 1) {
-        hamburger = document.createElement("div")
-        hamburger.setAttribute('id', 'hamburger')
-        document.querySelector('#nav ul.right').after(hamburger);
-        document.querySelector('ul.right').classList.add('has_hamburger');
+    // If either ID exists, close by pressing Escape
+    document.addEventListener('keyup', (key) => {
+      if (key.code == 'Escape') {
+        node.style.display = 'none';
+      }
+    });
+  });
+
+  // NAV BAR
+  //
+  // Insert the Hamburger if there are menu 2+ items
+  // Add "has_hamburger" class to the ul so CSS can know which way to show it.
+  if (document.querySelectorAll('#nav ul.right>li').length > 1) {
+    const hamburger = document.createElement('div');
+    hamburger.setAttribute('id', 'hamburger');
+    document.querySelector('#nav ul.right').after(hamburger);
+    document.querySelector('ul.right').classList.add('has_hamburger');
+  }
+
+  // Show the Mobile Menu on Hamburger Click
+  document.querySelectorAll('nav #hamburger').forEach((node) => {
+    node.addEventListener('click', () => {
+      document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+        node.style.display = node.style.display === 'inline-block' ? 'none' : 'inline-block';
+      });
+    });
+  });
+
+
+  // If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
+  window.onresize = function() {
+    if (window.innerWidth >= 1024) {
+      document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+        node.style.display = 'inline-block';
+      });
+    } else {
+      document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+        node.style.display = 'none';
+      });
     }
+  };
 
-    // Show the Mobile Menu on Hamburger Click
-    document.querySelectorAll('nav #hamburger').forEach(node => {
-        node.addEventListener('click', () => {
-            document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
-                node.style.display = node.style.display === 'inline-block' ? 'none' : 'inline-block';
-            });
+  // iPads don't have :hover, so hide the menu if the user clicks anything in <main>
+  document.querySelectorAll('main').forEach((node) => {
+    node.addEventListener('click', () => {
+      if (window.innerWidth < 1024) {
+        document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+          node.style.display = 'none';
         });
+      }
     });
+  });
 
-
-    // If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
-    window.onresize = function() {
-        if (document.window.innerWidth >= 1024) {
-            document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
-                node.style.display = 'inline-block';
-            });
-        } else {
-            document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
-                node.style.display = 'none';
-            });
-        }
-    };
-
-    // iPads don't have :hover, so hide the menu if the user clicks anything in <main>
-    document.querySelectorAll('main').forEach(node => {
-        node.addEventListener('click', () => {
-            if (document.documentElement.clientWidth < 1024) {
-                document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
-                    node.style.display = 'none';
-                });
-            }
-        });
-    });
-
-    // Deal with Really long menus
-    // Add "crowded" class to make them more compact.
-    document.querySelectorAll("#nav > ul > li > ul").forEach(node => {
-        if (node.children.length > 10) {
-            node.classList.add('crowded');
-        }
-    });
+  // Deal with Really long menus
+  // Add "crowded" class to make them more compact.
+  document.querySelectorAll('#nav > ul > li > ul').forEach((node) => {
+    if (node.children.length > 10) {
+      node.classList.add('crowded');
+    }
+  });
 };

--- a/app/assets/javascripts/dfm_web/dfm_web.js
+++ b/app/assets/javascripts/dfm_web/dfm_web.js
@@ -16,34 +16,40 @@ window.DfmWeb = {};
 
 DfmWeb.activate_dfm_web = function() {
 
-  // Hide the #notice and #alert messages by clicking the [X] or pressing escape key
-  document.querySelectorAll('#notice, #alert').forEach(node => {
-    node.addEventListener('click', (event) => {
-      console.log(node);
-      node.style.display = 'none';
-    });
+    // Hide the #notice and #alert messages by clicking the [X] or pressing escape key
+    document.querySelectorAll('#notice, #alert').forEach(node => {
+        node.addEventListener('click', () => {
+            node.style.display = 'none';
+        });
 
-    // If either ID exists, close by pressing Escape
-    document.addEventListener('keyup', (key) => {
-      if (key.code == 'Escape') {
-        node.style.display = 'none';
-      }
+        // If either ID exists, close by pressing Escape
+        document.addEventListener('keyup', (key) => {
+            if (key.code == 'Escape') {
+                node.style.display = 'none';
+            }
+        });
     });
-  });
 
     // NAV BAR
     //
     // Insert the Hamburger if there are menu 2+ items
     // Add "has_hamburger" class to the ul so CSS can know which way to show it.
-    if ($('#nav ul.right li').length > 1) {
-        $('ul.right').after('<div id="hamburger"></div>');
-        $('ul.right').addClass('has_hamburger');
+    if (document.querySelectorAll('#nav ul.right>li').length > 1) {
+        hamburger = document.createElement("div")
+        hamburger.setAttribute('id', 'hamburger')
+        document.querySelector('#nav ul.right').after(hamburger);
+        document.querySelector('ul.right').classList.add('has_hamburger');
     }
 
     // Show the Mobile Menu on Hamburger Click
-    $('nav #hamburger').click(function() {
-        return $("nav #nav ul.has_hamburger").toggle();
+    document.querySelectorAll('nav #hamburger').forEach(node => {
+        node.addEventListener('click', () => {
+            document.querySelectorAll("nav #nav ul.has_hamburger").forEach(node => {
+                node.style.display = node.style.display === 'inline-block' ? 'none' : 'inline-block';
+            });
+        });
     });
+
 
     // If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
     window.onresize = function() {

--- a/dfm_web.gemspec
+++ b/dfm_web.gemspec
@@ -28,11 +28,12 @@ Gem::Specification.new do |spec|
   # 4.0.0     | 5.1.7 | OK
   # 4.0.0     | 5.2.3 | OK
   # 4.0.0     | 6.0.0 | OK
-
+  # 4.0.2     | 7.0.1 | OK
 
   spec.add_dependency "rails", ">=5.1"            # Rails 5.1+
-  #spec.add_dependency 'jquery-rails'              # Jquery
 
   #spec.add_development_dependency 'jquery-tablesorter'
+  spec.add_development_dependency 'puma'
   spec.add_development_dependency "rspec-rails", '>= 3.5.0beta3'
+  spec.add_development_dependency 'sprockets-rails'
 end

--- a/dfm_web.gemspec
+++ b/dfm_web.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
 
 
   spec.add_dependency "rails", ">=5.1"            # Rails 5.1+
-  spec.add_dependency 'jquery-rails'              # Jquery
+  #spec.add_dependency 'jquery-rails'              # Jquery
 
-  spec.add_development_dependency 'jquery-tablesorter'
+  #spec.add_development_dependency 'jquery-tablesorter'
   spec.add_development_dependency "rspec-rails", '>= 3.5.0beta3'
 end

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "4.1.3"
+  VERSION = "5.0.0"
 end
 
 
 # Version History
 
+# 5.0.0   Remove jQuery as a requirement and update README etc for Rails 7.
 # 4.1.3   Accessibility and Print media improvements. Added /print demo to Dummy app.
 # 4.1.2   Add example theme-colors to dummy & Update NAV CSS. Added a nav search box.
 # 4.1.1   Remove alpha channel on option/select background as it's unsupported in Windows.

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -10,16 +10,15 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery2
-//= require jquery_ujs
-//= require jquery-tablesorter
 //= require dfm_web/dfm_web
 //= require_self
 
-// See dfm_web/dfm_web.js.coffee for information
-$(document).on('ready page:load', function() {
+// See dfm_web/dfm_web.js for information
+document.addEventListener("DOMContentLoaded",function() {
     DfmWeb.activate_dfm_web();
-    $("#window_width").html(window.innerWidth);
-    window.addEventListener('resize', () => {$("#window_width").html(window.innerWidth);} );
-    $('.tablesorter').tablesorter({widgets: ['zebra']})
+    document.getElementById("window_width").innerHTML = window.innerWidth;
+})
+
+window.addEventListener("resize", function() {
+    document.getElementById("window_width").innerHTML = window.innerWidth;
 });

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -18,12 +18,12 @@ class ApplicationController < ActionController::Base
   def pure
   end
 
-  def notice
+  def notice_example
     flash[:notice] = "This is a notice message.<br>It can be <i>long</i> and include <b>basic</b> HTML."
     redirect_to root_url
   end
 
-  def alert
+  def alert_example
     flash[:alert] = "This is an alert message"
     redirect_to root_url
   end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -5,8 +5,6 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require 'jquery-rails'
-require 'jquery-tablesorter'
 
 
 Bundler.require(*Rails.groups)

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
   # See how all your routes lay out with "rake routes".
 
 
-  get 'alert'  => 'application#alert'
-  get 'notice' => 'application#notice'
+  get 'alert'  => 'application#alert_example'
+  get 'notice' => 'application#notice_example'
   get 'news'   => 'application#news'
   get 'print'  => 'application#print'
   get 'pure'   => 'application#pure'


### PR DESCRIPTION
Fixes #89 

After upgrading a project using this gem from jQuery 2 -> 3 we needed to clean up the jQuery deprecations here.  jQuery not being as ubiquitous as it once was and considering we have less than 100 lines of javascript, this PR rewrites everything in vanilla Javascript (ES6). 

### Bumping Major version number 4 -> 5 in case any issues arise with the new javascript code (easier to stay below the change in that situation).


Notes:
* jquery-tablesorter was removed from the spec/dummy app so that we could also remove jquery there.  It still works fine if you include it in your host app.
* [ESLint](https://eslint.org/) was run on dfm_web.js and suggestions implemented.
* The notice/alert box animation wasn't reimplemented.
* `notice` and `alert` controller actions [renamed for Rails 7 compatibility](https://github.com/DFMCH/dfm_web/pull/90/commits/c19dabf314f8f7e562dd900752e45705a52786c2). 


Tested on: (WIP)

|                     | Rails 5.2 | Rails 6.0 | Rails 6.1 | Rails 7.0 |
-------------|----------|----------|---------|---------| 
Plain              |       ✓       |       ✓       |        ✓    |       ✓        |
Turbolinks     |                |                 |        ✓      |               |
Turbo             |      -          |       -          |        -        |        ✓       |


