### PR TITLE
Support Internet Explorer 11

### DIFF
--- a/app/assets/javascripts/dfm_web/dfm_web.js
+++ b/app/assets/javascripts/dfm_web/dfm_web.js
@@ -22,13 +22,13 @@ window.DfmWeb = {};
 
 DfmWeb.activate_dfm_web = function() {
   // Hide the #notice and #alert messages by clicking the [X] or pressing escape key
-  document.querySelectorAll('#notice, #alert').forEach((node) => {
-    node.addEventListener('click', () => {
+  document.querySelectorAll('#notice, #alert').forEach(function (node) {
+    node.addEventListener('click', function () {
       node.style.display = 'none';
     });
 
     // If either ID exists, close by pressing Escape
-    document.addEventListener('keyup', (key) => {
+    document.addEventListener('keyup', function (key) {
       if (key.code == 'Escape') {
         node.style.display = 'none';
       }
@@ -40,16 +40,16 @@ DfmWeb.activate_dfm_web = function() {
   // Insert the Hamburger if there are menu 2+ items
   // Add "has_hamburger" class to the ul so CSS can know which way to show it.
   if (document.querySelectorAll('#nav ul.right>li').length > 1) {
-    const hamburger = document.createElement('div');
+    var hamburger = document.createElement('div');
     hamburger.setAttribute('id', 'hamburger');
     document.querySelector('#nav ul.right').after(hamburger);
     document.querySelector('ul.right').classList.add('has_hamburger');
   }
 
   // Show the Mobile Menu on Hamburger Click
-  document.querySelectorAll('nav #hamburger').forEach((node) => {
-    node.addEventListener('click', () => {
-      document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+  document.querySelectorAll('nav #hamburger').forEach(function (node) {
+    node.addEventListener('click', function () {
+      document.querySelectorAll('nav #nav ul.has_hamburger').forEach(function (node) {
         node.style.display = node.style.display === 'inline-block' ? 'none' : 'inline-block';
       });
     });
@@ -59,21 +59,21 @@ DfmWeb.activate_dfm_web = function() {
   // If you've toggled the Mobile menu it breaks larger sizes.  Reset on resize.
   window.onresize = function() {
     if (window.innerWidth >= 1024) {
-      document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+      document.querySelectorAll('nav #nav ul.has_hamburger').forEach(function (node) {
         node.style.display = 'inline-block';
       });
     } else {
-      document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+      document.querySelectorAll('nav #nav ul.has_hamburger').forEach(function (node) {
         node.style.display = 'none';
       });
     }
   };
 
   // iPads don't have :hover, so hide the menu if the user clicks anything in <main>
-  document.querySelectorAll('main').forEach((node) => {
-    node.addEventListener('click', () => {
+  document.querySelectorAll('main').forEach(function (node) {
+    node.addEventListener('click', function () {
       if (window.innerWidth < 1024) {
-        document.querySelectorAll('nav #nav ul.has_hamburger').forEach((node) => {
+        document.querySelectorAll('nav #nav ul.has_hamburger').forEach(function (node) {
           node.style.display = 'none';
         });
       }
@@ -82,7 +82,7 @@ DfmWeb.activate_dfm_web = function() {
 
   // Deal with Really long menus
   // Add "crowded" class to make them more compact.
-  document.querySelectorAll('#nav > ul > li > ul').forEach((node) => {
+  document.querySelectorAll('#nav > ul > li > ul').forEach(function (node) {
     if (node.children.length > 10) {
       node.classList.add('crowded');
     }

--- a/app/assets/javascripts/dfm_web/internet_explorer.js
+++ b/app/assets/javascripts/dfm_web/internet_explorer.js
@@ -1,0 +1,72 @@
+/* Polyfill service v3.110.1
+ * For detailed credits and licence information see https://github.com/financial-times/polyfill-service.
+ *
+ * Features requested: Element.prototype.after,NodeList.prototype.forEach
+ *
+ * - _mutation, License: CC0 (required by "Element.prototype.after")
+ * - Element.prototype.after, License: CC0
+ * - NodeList.prototype.forEach, License: CC0 */
+
+(function(self, undefined) {
+
+// _mutation
+  var _mutation = (function () { // eslint-disable-line no-unused-vars
+
+    function isNode(object) {
+      // DOM, Level2
+      if (typeof Node === 'function') {
+        return object instanceof Node;
+      }
+      // Older browsers, check if it looks like a Node instance)
+      return object &&
+        typeof object === "object" &&
+        object.nodeName &&
+        object.nodeType >= 1 &&
+        object.nodeType <= 12;
+    }
+
+    // http://dom.spec.whatwg.org/#mutation-method-macro
+    return function mutation(nodes) {
+      if (nodes.length === 1) {
+        return isNode(nodes[0]) ? nodes[0] : document.createTextNode(nodes[0] + '');
+      }
+
+      var fragment = document.createDocumentFragment();
+      for (var i = 0; i < nodes.length; i++) {
+        fragment.appendChild(isNode(nodes[i]) ? nodes[i] : document.createTextNode(nodes[i] + ''));
+
+      }
+      return fragment;
+    };
+  }());
+
+// Element.prototype.after
+  /* global _mutation */
+  Document.prototype.after = Element.prototype.after = function after() {
+    if (this.parentNode) {
+      var args = Array.prototype.slice.call(arguments),
+        viableNextSibling = this.nextSibling,
+        idx = viableNextSibling ? args.indexOf(viableNextSibling) : -1;
+
+      while (idx !== -1) {
+        viableNextSibling = viableNextSibling.nextSibling;
+        if (!viableNextSibling) {
+          break;
+        }
+        idx = args.indexOf(viableNextSibling);
+      }
+
+      this.parentNode.insertBefore(_mutation(arguments), viableNextSibling);
+    }
+  };
+
+// Not all UAs support the Text constructor.  Polyfill on the Text constructor only where it exists
+// TODO: Add a polyfill for the Text constructor, and make it a dependency of this polyfill.
+  if ("Text" in self) {
+    Text.prototype.after = Element.prototype.after;
+  }
+
+// NodeList.prototype.forEach
+  NodeList.prototype.forEach = Array.prototype.forEach;
+})
+('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "5.0.0"
+  VERSION = "5.0.1"
 end
 
 
 # Version History
 
+# 5.0.1   Restore compatibility with Internet Explorer 11.
 # 5.0.0   Remove jQuery as a requirement and update README etc for Rails 7.
 # 4.1.3   Accessibility and Print media improvements. Added /print demo to Dummy app.
 # 4.1.2   Add example theme-colors to dummy & Update NAV CSS. Added a nav search box.

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -10,6 +10,11 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+// Note: The internet_explorer require below is optional.
+//       Add if you wish to support Internet Explorer 11.
+//       It adds two polyfills used by dfm_web
+//
+//= require dfm_web/internet_explorer
 //= require dfm_web/dfm_web
 //= require_self
 

--- a/spec/dummy/app/views/application/news.html.erb
+++ b/spec/dummy/app/views/application/news.html.erb
@@ -15,7 +15,7 @@
 <h2>Headlines</h2>
 
 <div class="panel" id="sasuke">
-  <h2>Sasuke Flips Car</h2>
+  <h2>Local Events</h2>
   <% 2.times do %>
     <%= render 'lorem' %>
   <% end %>
@@ -23,7 +23,7 @@
 
 
 <div class="panel" id="ricky">
-  <h2>Ricky Faces Jail Time</h2>
+  <h2>School Closings</h2>
   <% 3.times do %>
     <%= render 'lorem' %>
   <% end %>

--- a/spec/dummy/app/views/layouts/_nav.html.erb
+++ b/spec/dummy/app/views/layouts/_nav.html.erb
@@ -33,8 +33,8 @@
         <%= link_to "News", news_path %>
         <ul>
           <li><%= link_to("#{Date.today.strftime("%A")}'s Weather", news_path + "#weather") %></li>
-          <li><%= link_to('Sasuke Flips Car', news_path + "#sasuke") %></li>
-          <li><%= link_to('Ricky Faces Jail Time', news_path + "#ricky") %></li>
+          <li><%= link_to('Local Events', news_path + "#sasuke") %></li>
+          <li><%= link_to('School Closings', news_path + "#ricky") %></li>
         </ul>
       </li>
 


### PR DESCRIPTION
Fixes #91 

* Refactors ES6 `=>` back into ES5 style (not a big deal)
* Adds `internet_explorer.js` containing two polyfills for features not supported in IE we use.
* Require the internet explorer file if you want to support IE.  It does nothing on supported browsers.
  - `//= require dfm_web/internet_explorer`
* Don't include the `js` if you'd rather to put a fork in IE.


### IE11 Console free of errors
<img width="1282" alt="Screen Shot 2022-03-02 at 1 35 32 PM" src="https://user-images.githubusercontent.com/382216/156436447-00663820-d530-42d0-80e4-f4f26b0b0f0a.png">

