### PR TITLE
Removed all mention of verlag font, and updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,14 @@ Rails.application.config.assets.precompile += %w( dfm_web/* )
 * All jQuery based code has been rewritten in Javascript (ES6)
 * Updated README and comments on use with Rails 7 (Turbo or plain).
   - Rails 7 tests were performed on an esbuild + sass setup
+* The default font has changed to Red Hat Text.
+  - https://fonts.google.com/specimen/Red+Hat+Text
 
 ### Version 4:
 * Now using the UW look and feel.
-* UW font (verlag) cannot be added to the repo per licensing requirements.
-  - To use it in your site add verlag.css to your host app (provided by UW).
-  - It will be used if available with fallback to Helvetica etc.
 * Navbar img is no longer vertically centered in CSS.
   - Pad your PNG/SVG with transparency.
-  - Image be scaled to 42px, but PNG should be at least double that.
+  - Image will be scaled to 42px, but a raster image should be at least double that.
 
 
 ### Version 3:

--- a/app/assets/stylesheets/dfm_web/style.css.erb
+++ b/app/assets/stylesheets/dfm_web/style.css.erb
@@ -12,7 +12,7 @@ UW GRAY FOOTER TEXT HOVER	$uw-gray-footer-text-hover	#f9f9f9	Used for links in f
 */
 
 html, .pure-g, .pure-g [class *= "pure-u"] {
-  font-family: 'Red Hat Text', 'Verlag', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Red Hat Text', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 /* html tag should really only have background styles */

--- a/lib/dfm_web/version.rb
+++ b/lib/dfm_web/version.rb
@@ -1,10 +1,11 @@
 module DfmWeb
-  VERSION = "5.0.3"
+  VERSION = "5.0.4"
 end
 
 
 # Version History
 
+# 5.0.4   Removed verlag font from the font-family list as no one should be using it.  Font itself was never present.
 # 5.0.2   Scale the new font to 88% to match the old one and use black instead of dark gray for the base.
 # 5.0.2   Added RedHat font now used by UW Madison as the official marketing font.
 # 5.0.1   Restore compatibility with Internet Explorer 11.


### PR DESCRIPTION
* Bump version to 5.0.4
* No user side changes (unless you were still using Verlag, which you shouldn't be anymore).
* README updated to mention the use of "Red Hat Text" as the default font, which is included here.